### PR TITLE
SR/send fewer reconciliation trades

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "order-manager"
-version = "11.3.0"
+version = "11.3.1"
 dependencies = [
  "alpaca 0.9.0",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "order-manager"
-version = "11.3.0"
+version = "11.3.1"
 authors = ["Sebastian Rollen <seb@overmu.se>"]
 edition = "2018"
 


### PR DESCRIPTION
- only reconcile for tickers where there are no pending trades
- version bump
